### PR TITLE
#14 - OpenAPITestHelper loggolás kikapcsolási lehetősége

### DIFF
--- a/docs/migration.adoc
+++ b/docs/migration.adoc
@@ -16,7 +16,7 @@ Következő szekció a verzió kiadások közötti változásokat írja le.
 ==== roaster-restassured
 * A default JSON object mapper az idő értékeket ISO formátumra serializálja az eddigi "1600871093.907000000" helyett.
 
-* Megszünt a deprecated lehetőség 
+* Megszünt a deprecated lehetőség
 
 [source,java]
 ----
@@ -38,7 +38,7 @@ private RestAssuredConfig restAssuredConfig;
 
 ==== Átállás
 
-Az IT tesztekből ki kell venni az eddig manualisan hozzáadott bean-eket, egyébként 
+Az IT tesztekből ki kell venni az eddig manualisan hozzáadott bean-eket, egyébként
 "Bean name is ambiguous." hibaüzenetet kapunk.
 [source,java]
 ----
@@ -56,7 +56,7 @@ protected void configureWeld(Weld weld) {
 
 ==== Átállás
 
-A unit tesztekből ki kell venni az eddig manualisan hozzáadott bean-eket, egyébként 
+A unit tesztekből ki kell venni az eddig manualisan hozzáadott bean-eket, egyébként
 "Bean name is ambiguous." hibaüzenetet kapunk.
 [source,java]
 ----
@@ -124,3 +124,9 @@ A FileUtil-t érintő dependency és package változásokat szükséges átvezet
 
 ==== Általános
 coff:ee frissítés 1.5.0 → 1.6.0
+
+==== roaster-restassured
+* Az OpenAPITestHelper osztály kiegészült a request és response loggolásának kikapcsolási lehetőségével egy új metóduson keresztül.
+
+==== Átállás
+A változtatások nem eredményeznek átállási munkálatokat, visszafelé kompatibilis.


### PR DESCRIPTION
* Request és response loggolásának állítására bevezetésre került 1-1 boolean paraméter amivel szabályozható a loggolás.
* Migrációs dokumentum kiegészítve.